### PR TITLE
make title smaller to be more proportionate to the rest of the page

### DIFF
--- a/css/application.css
+++ b/css/application.css
@@ -293,7 +293,7 @@ b {
     -webkit-transform: rotate3d(0, 0, 0, 0);
 }
 .title {
-    font-size: 3em;
+    font-size: 2em;
     color: white;
     text-align: center;
     font-weight: normal;


### PR DESCRIPTION
This is probably just personal preference but I'm a fan of the 'Date' and 'Location' text being smaller, compared to the time and weather. I see that @vinitkumar made the text a bit bigger in #3, so if you don't like this, feel free to just close it.

![screen shot 2014-09-26 at 1 39 55 pm](https://cloud.githubusercontent.com/assets/3671762/4427285/8a32fa8c-45bd-11e4-8618-8d6db11820fe.png)
